### PR TITLE
Update Xcloner_File_System.php

### DIFF
--- a/vendor/watchfulli/xcloner-core/src/Xcloner_File_System.php
+++ b/vendor/watchfulli/xcloner-core/src/Xcloner_File_System.php
@@ -516,14 +516,9 @@ class Xcloner_File_System
                 $this->get_tmp_filesystem()->delete($file_info['path']);
             }
         }
-
-        try {
-            if (is_dir($tmp_path)) {
-                rmdir($tmp_path);
-            }
-        } catch (\Exception $e) {
-            //silent continue
-        }
+        
+        if (is_dir($tmp_path)) {
+            rmdir($tmp_path);
 
         return;
     }


### PR DESCRIPTION
As rmdir never throws exceptions, try...catch block is unnecessary and confusing. One might be surprised that warnings are still appearing.