### PR TITLE
changing icons for upload and restore buttons

### DIFF
--- a/admin/partials/xcloner_restore_page.php
+++ b/admin/partials/xcloner_restore_page.php
@@ -103,7 +103,7 @@ $backup_list = $xcloner_file_system->get_latest_backups();
                         <div class="toggler">
                             <button class="btn waves-effect waves-light upload-backup normal" type="submit" id=""
                                 name="action"><?php echo __("Upload", 'xcloner-backup-and-restore') ?>
-                                <i class="material-icons left">navigate_before</i>
+                                <i class="material-icons left">upload</i>
                             </button>
                             <button class="btn waves-effect waves-light red upload-backup cancel" type="submit" id=""
                                 name="action"><?php echo __("Cancel", 'xcloner-backup-and-restore') ?>
@@ -244,7 +244,7 @@ $backup_list = $xcloner_file_system->get_latest_backups();
                         <div class="toggler">
                             <button class="btn waves-effect waves-light restore_remote_backup normal " type="submit"
                                 id="" name="action"><?php echo __("Restore", 'xcloner-backup-and-restore') ?>
-                                <i class="material-icons left">navigate_before</i>
+                                <i class="material-icons left">download</i>
                             </button>
                             <button class="btn waves-effect waves-light red restore_remote_backup cancel" type="submit"
                                 id="" name="action"><?php echo __("Cancel", 'xcloner-backup-and-restore') ?>

--- a/admin/partials/xcloner_restore_page.php
+++ b/admin/partials/xcloner_restore_page.php
@@ -371,7 +371,7 @@ $backup_list = $xcloner_file_system->get_latest_backups();
                         <div class="toggler">
                             <button class="btn waves-effect waves-light restore_remote_mysqldump normal " type="submit"
                                 id="" name="action"><?php echo __("Restore", 'xcloner-backup-and-restore') ?>
-                                <i class="material-icons left">navigate_before</i>
+                                <i class="material-icons left">download</i>
                             </button>
                             <button class="btn waves-effect waves-light red restore_remote_mysqldump cancel"
                                 type="submit" id=""


### PR DESCRIPTION
Upload and restore buttons used right now are confusing to the user, updated them with proper ones.

## Upload button
#### Before
![Screenshot 2021-04-21 at 3 43 13 PM](https://user-images.githubusercontent.com/8397274/115538148-35c9d000-a2b9-11eb-9930-ec6184beb15a.png)
#### After
![Screenshot 2021-04-21 at 3 42 30 PM](https://user-images.githubusercontent.com/8397274/115537861-e08dbe80-a2b8-11eb-9c2e-208d6a4e9623.png)

## Restore button
#### Before
![Screenshot 2021-04-21 at 3 44 23 PM](https://user-images.githubusercontent.com/8397274/115538684-c6a0ab80-a2b9-11eb-8bd7-759357c0419d.png)

#### After
![Screenshot 2021-04-21 at 3 44 05 PM](https://user-images.githubusercontent.com/8397274/115538721-cef8e680-a2b9-11eb-885e-85d53ff0e572.png)
